### PR TITLE
Allow editing of blog article posts

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -31,6 +31,16 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Is Draft", name: "bookHidden", widget: "boolean"}
       - {label: "Body", name: "body", widget: "markdown"}
+  - name: "posts" # Used in routes, ie.: /admin/collections/:slug/edit
+    label: "post" # Used in the UI, ie.: "New Experiment"
+    folder: "site/content/posts" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields each document in this collection have
+      - {label: "Author", name: "author", widget: "string"}
+      - {label: "Publish Date", name: "date", widget: "datetime"}
+      - {label: "Link Title", name: "linktitle", widget: "string"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Body", name: "body", widget: "markdown"}
   # - name: "pages"
   #   label: "Pages"
   #   files:


### PR DESCRIPTION
After the new theme was applied the blog article section was no longer editable.
This changes the netlify admin configuration to allow editing the posts through the admin interface.